### PR TITLE
Truncate test tables

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,18 +20,18 @@ THIS SHOULD BE REFACTORED INTO A CONDITIONAL, SO THAT IT ONLY HAPPENS WHEN RUNNI
 NOTE: IN TEST MODE: IF THE TABLES DON'T EXIST, THE FIRST TEST MAY FAIL AND THE REST MAY WORK. AND THEN WHEN YOU RE-RUN THE TESTS, ALL TESTS PASS. THIS IS BECAUSE THE .SYNC HASN'T FINISHED CREATING THE MISSING TABLES BEFORE THE FIRST TEST HAS EXECUTED AND RETURNED IT'S RESULT.
 TO RECREATE: DELETE TABLES FROM TEST DATABASE. RUN TEST SUITE. LOOK FOR THE CONSOLE LOG MESSAGES SHOWING WHEN THE TABLES WERE CREATED (THEY'LL BE RIGHT BEFORE THE TESTS START PASSING!)
 */
-if (process.env.npm_lifecycle_event === 'test') {
-  // Property.sync().then((responses) => {
-  //   console.log('**** properties table set up ****');
-  // })
-  // User.sync().then((responses) => {
-  //   console.log('**** users table set up ****');
-  // })
-  console.log('tables reached');
-  User.truncate()
-  Property.truncate()
-  console.log("tables emptied")
-}
+// if (process.env.npm_lifecycle_event === 'test') {
+//   // Property.sync().then((responses) => {
+//   //   console.log('**** properties table set up ****');
+//   // })
+//   // User.sync().then((responses) => {
+//   //   console.log('**** users table set up ****');
+//   // })
+//   console.log('tables reached');
+//   User.truncate()
+//   Property.truncate()
+//   console.log("tables emptied")
+// }
 
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
@@ -153,3 +153,4 @@ if (process.env.npm_lifecycle_event !== 'test') {
 
 // THIS NEEDS TO BE AT THE END, NOT THE START!
 module.exports = app
+// module.exports = User

--- a/app.js
+++ b/app.js
@@ -14,24 +14,15 @@ const User = require(path.join(__dirname, 'server/models/user'))(sequelize, Sequ
 const Property = require(path.join(__dirname, 'server/models/property'))(sequelize, Sequelize);
 
 /*
-THIS CHECKS IF THE TABLES EXIST IN THE DATABASE OF THE CURRENT RUNNING ENVIROMENT (TEST OR NON-TEST).
-IF THE TABLES DON'T EXIST, IT WILL CREATE THEM FROM THE RELEVANT MODELS.
-THIS SHOULD BE REFACTORED INTO A CONDITIONAL, SO THAT IT ONLY HAPPENS WHEN RUNNING IN TEST MODE.
-NOTE: IN TEST MODE: IF THE TABLES DON'T EXIST, THE FIRST TEST MAY FAIL AND THE REST MAY WORK. AND THEN WHEN YOU RE-RUN THE TESTS, ALL TESTS PASS. THIS IS BECAUSE THE .SYNC HASN'T FINISHED CREATING THE MISSING TABLES BEFORE THE FIRST TEST HAS EXECUTED AND RETURNED IT'S RESULT.
-TO RECREATE: DELETE TABLES FROM TEST DATABASE. RUN TEST SUITE. LOOK FOR THE CONSOLE LOG MESSAGES SHOWING WHEN THE TABLES WERE CREATED (THEY'LL BE RIGHT BEFORE THE TESTS START PASSING!)
+NOTE: THIS RESETS THE TEST DATABASE'S TABLES TO EMPTY. THEY WILL BE FILLED WITH TEST DATA AFTERWARDS. THEY SHOULD BE CLEARED AS PART OF THE TEST CYCLE, NOT HERE!
+AN ERROR WILL THROW IF THE TABLES DON'T EXIST (THEY CAN BE CRETED USING .SYNC BUT WHEN THE TEST SUITE IS RUN THE FIRST TIME WITH THIS, IT CAN CAUSE FALSE ERRORS AS ITS ASYNC EVALUATED.... SO JUST RUN THE TESTS AGAIN )
 */
-// if (process.env.npm_lifecycle_event === 'test') {
-//   // Property.sync().then((responses) => {
-//   //   console.log('**** properties table set up ****');
-//   // })
-//   // User.sync().then((responses) => {
-//   //   console.log('**** users table set up ****');
-//   // })
-//   console.log('tables reached');
-//   User.truncate()
-//   Property.truncate()
-//   console.log("tables emptied")
-// }
+if (process.env.npm_lifecycle_event === 'test') {
+  console.log('clearing test tables.....');
+  User.truncate()
+  Property.truncate()
+  console.log(".....test tables emptied")
+}
 
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
@@ -122,7 +113,7 @@ app.get("/add_property", function (req, res) {
 
 app.post("/add_property", function (req, res) {
   var name = req.session.name;
-  
+
   if (req.session.name === null) {
     res.redirect("login")
   }

--- a/spec/featureSpec.js
+++ b/spec/featureSpec.js
@@ -3,7 +3,6 @@
 */
 
 const Browser = require('zombie');
-// const Helper = require('./helpers/web_helpers')
 
 /*
 BEFORE RUNNING TESTS, WE WANT TO MAKE SURE THE APP IS UP AND RUNNING ON LOCALHOST - OTHERWISE ZOMBIE CAN'T 'SEE' WHAT'S GOING ON.
@@ -14,38 +13,31 @@ Browser.localhost('example.com', 4000);
 
 var app = require('../app');
 
-/*
-THE LINES RELATING TO SERVER START / STOP CAN BE REFACTORED OUT TO A SEPARATE FILE, E.G. web_helpers (WHICH CAN THEN BE UNCOMMENTED OUT AT THE TOP!)
-WHEN THE FUNCTIONALITY TO WIPE THE TEST DATABASES BEFORE / AFTER EACH IS ADDED, IT SHOULD BE EXTRACTED SIMILARLY
-*/
-
 var server;
-var startServer = () => { server = app.listen(4000) }
-var stopServer = () => { server.close() }
-/*
-THE TWO (startServer / stopServer) HAVE TO BE CALLED IN beforeEach AND afterEach FUNCTIONS - AFAIK THEY CAN'T JUST BE SET ONCE AT START OF TEST SUITE :(
-*/
+var startServer = () => { server = app.listen(4000) };
+var stopServer = () => { server.close() };
+
+// var User;
+// var userTruncate = () => { User.truncate }
 
 const browser = new Browser();
 describe('Global server set up', function(){
   beforeEach(function() {
-    startServer()
+    startServer();
+    // userTruncate()
+      // if err then throw err else done()
+    // })
     return browser.visit('/');
-  })
+  });
 
   afterEach(function(){
-    stopServer()
+    stopServer();
   });
 
 
   describe('User visits homepage', function() {
     beforeEach(function() {
-      // startServer()
       return browser.visit('/');
-    })
-
-    afterEach(function(){
-      // stopServer()
     });
 
     describe('Register', function() {
@@ -103,18 +95,9 @@ describe('Global server set up', function(){
     });
   });
 
-  /*
-  THIS SUITE OF TESTS NEEDS FIXING!
-  PLEASE NOTE ADDITION OF startServer AND stopServer
-  */
   describe('Nav bar', function() {
     beforeEach(function() {
-      // startServer()
       return browser.visit('/');
-    });
-
-    afterEach(function(){
-      // stopServer()
     });
 
     describe('When user is logged in', function() {
@@ -140,12 +123,7 @@ describe('Global server set up', function(){
 
   describe('Nav bar', function() {
     beforeEach(function() {
-      // startServer()
       return browser.visit('/');
-    });
-
-    afterEach(function(){
-      // stopServer()
     });
 
     describe('When user is not logged in', function() {
@@ -162,12 +140,7 @@ describe('Global server set up', function(){
 
   describe('View all properties', function() {
     beforeEach(function() {
-      // startServer()
       return browser.visit('/properties');
-    });
-
-    afterEach(function(){
-      // stopServer()
     });
 
     it('expect to have title of properties page', function() {

--- a/spec/featureSpec.js
+++ b/spec/featureSpec.js
@@ -120,7 +120,6 @@ describe('Global server set up', function(){
 
   });
 
-
   describe('Nav bar', function() {
     beforeEach(function() {
       return browser.visit('/');


### PR DESCRIPTION
a compromise approach...

This truncates (empties the data) out of the test database's tables.
It runs once, when the app.js file is called from the test file.

This means it only empties the data ONCE, before ALL the tests are run (this is important!)
It means tests are then using tables that have other data in them, which could cause issues (false positives/ negatives). 

Using .truncate instead of .sync as the test tables are already in existence in our could db, and sync can cause tests to prematurely fail IF the tables don't exist (tests don't wait for the tables to be created before they start running / evaluating).